### PR TITLE
CreateCTA has url validation, CreateSingleText accepts validation rul…

### DIFF
--- a/__tests__/createCTA.js
+++ b/__tests__/createCTA.js
@@ -48,6 +48,7 @@ describe('createCTA', () => {
       localized: false,
       fieldset: null,
       validators: {
+        format: { predefined_pattern: 'url' },
         required: {},
       },
       appearance: {
@@ -58,6 +59,48 @@ describe('createCTA', () => {
         },
       },
     });
+  });
+
+  it('Create validated URL field', async () => {
+    const mockCreate = jest.fn(() => Promise.resolve({ id: '123' }));
+    const client = {
+      fields: {
+        create: mockCreate,
+      },
+    };
+
+    const options = {
+      label: 'Button',
+      apiKey: 'button',
+    };
+
+    const modelId = '1';
+    await createCTA(client, options, modelId);
+
+    const returnValue = {
+      apiKey: 'button_url',
+      fieldType: 'string',
+      hint: null,
+      label: 'Button URL',
+      localized: false,
+      fieldset: null,
+      validators: {
+        format: { predefined_pattern: 'url' },
+      },
+      appearance: {
+        editor: 'single_line',
+        addons: [],
+        parameters: {
+          heading: false,
+        },
+      },
+    };
+
+    expect(mockCreate.mock.calls[0][0]).toEqual(modelId);
+    expect(mockCreate.mock.calls[0][1]).not.toEqual(returnValue);
+
+    expect(mockCreate.mock.calls[1][0]).toEqual(modelId);
+    expect(mockCreate.mock.calls[1][1]).toEqual(returnValue);
   });
 
   it('create optional field', async () => {

--- a/__tests__/createSingleLine.js
+++ b/__tests__/createSingleLine.js
@@ -75,6 +75,51 @@ describe('createSingleLine', () => {
     });
   });
 
+  it('create validation fields', async () => {
+    const mockCreate = jest.fn(() => Promise.resolve({ id: '123' }));
+    const client = {
+      fields: {
+        create: mockCreate,
+      },
+    };
+
+    const options = {
+      label: 'String',
+      apiKey: 'string',
+      validators: {
+        format: { predefined_pattern: 'url' },
+      },
+    };
+
+    const noValidationOoptions = {
+      label: 'String',
+      apiKey: 'string',
+    };
+
+    const modelId = '1';
+    await createSingleLine(client, options, modelId);
+
+    expect(mockCreate.mock.calls[0][0]).toEqual(modelId);
+    expect(mockCreate.mock.calls[0][1]).toEqual({
+      apiKey: 'string',
+      fieldType: 'string',
+      hint: null,
+      label: 'String',
+      localized: false,
+      fieldset: null,
+      validators: {
+        format: { predefined_pattern: 'url' },
+      },
+      appearance: {
+        editor: 'single_line',
+        addons: [],
+        parameters: {
+          heading: false,
+        },
+      },
+    });
+  });
+
   it('throws an error when no client is passed', async () => {
     const modelId = '1';
     try {

--- a/src/createCTA.js
+++ b/src/createCTA.js
@@ -20,6 +20,7 @@ const createCTA = async (
     { label, apiKey, localized, fieldset, ...params },
     modelId
   );
+
   await createSingleLine(
     client,
     {
@@ -27,6 +28,9 @@ const createCTA = async (
       apiKey: `${apiKey}_url`,
       localized,
       fieldset,
+      validators: {
+        format: { predefined_pattern: 'url' },
+      },
       ...params,
     },
     modelId

--- a/src/createSingleLine.js
+++ b/src/createSingleLine.js
@@ -17,18 +17,26 @@ const createSingleLine = async (
   if (!client) throw new Error('client cannot be undefined');
   if (!modelId) throw new Error('Model ID cannot be undefined');
 
-  const validators = {};
+  let validators = {};
 
-  if (required) validators.required = {};
+  if (required || params.required) {
+    validators.required = {};
+    params.required = undefined;
+    required = undefined;
+  }
+  if (params.validators) {
+    validators = { ...params.validators, ...validators };
+    delete params.validators;
+  }
 
   return client.fields.create(modelId, {
     label,
     apiKey,
     fieldType: 'string',
-    validators,
     hint,
     localized,
     fieldset,
+    validators: validators,
     appearance: {
       editor: 'single_line',
       addons: [],


### PR DESCRIPTION
Adds `format: { predefined_pattern: 'url'}` to url field in `createCta` and adds validation logic to `createSingleText` since it only allowed `required`.

